### PR TITLE
fix: mod 10 incase digit is 0, e.g. (10 - 0) mod 10 = 0.

### DIFF
--- a/validator-function.php
+++ b/validator-function.php
@@ -83,7 +83,7 @@ function bluCB1609_verify_id_number($id_number, $return_details = false) {
 		$last_digit = substr($sum, -1);
 
 		// 10 - $last_digit
-		$verify_check_digit = 10 - (int)$last_digit;
+		$verify_check_digit = (10 - (int)$last_digit) % 10;
 
 		// test expected last digit against the last digit in $id_number submitted
 		if ((int)$verify_check_digit !== (int)$check_digit) {


### PR DESCRIPTION
It fails for some valid IDs, with mod 10 it works.